### PR TITLE
feat: data.location from Hooks v2 API

### DIFF
--- a/on-add-nautical.py
+++ b/on-add-nautical.py
@@ -53,9 +53,16 @@ _MAX_JSON_BYTES = 10 * 1024 * 1024
 # --------------------------------------------------------------------------------------
 # Locate and import nautical_core (single fixed location: ~/.task)
 # --------------------------------------------------------------------------------------
+
+try:
+    # Get the fifth argument and remove the "data:" prefix
+    hook_data_arg = len(sys.argv) > 5 and len(sys.argv[5]) >= 5 and Path(sys.argv[5][5:])
+except Exception:
+    hook_data_arg = None
+
 HOOK_DIR = Path(__file__).resolve().parent
 TW_DIR = HOOK_DIR.parent
-TW_DATA_DIR = Path(os.environ.get("TASKDATA") or str(TW_DIR)).expanduser()
+TW_DATA_DIR = hook_data_arg or Path(os.environ.get("TASKDATA") or str(TW_DIR)).expanduser()
 
 # --- Optional micro-profiler (stderr-only; enable with NAUTICAL_PROFILE=1 or 2)
 _PROFILE_LEVEL = int(os.environ.get('NAUTICAL_PROFILE', '0') or '0')

--- a/on-exit-nautical.py
+++ b/on-exit-nautical.py
@@ -55,7 +55,14 @@ try:
                 pass
 except Exception:
     core = None
-TW_DATA_DIR = Path(os.environ.get("TASKDATA") or str(TW_DIR)).expanduser()
+
+try:
+    # Get the fifth argument and remove the "data:" prefix
+    hook_data_arg = len(sys.argv) > 5 and len(sys.argv[5]) >= 5 and Path(sys.argv[5][5:])
+except Exception:
+    hook_data_arg = None
+
+TW_DATA_DIR = hook_data_arg or Path(os.environ.get("TASKDATA") or str(TW_DIR)).expanduser()
 
 _QUEUE_PATH = TW_DATA_DIR / ".nautical_spawn_queue.jsonl"
 _QUEUE_PROCESSING_PATH = TW_DATA_DIR / ".nautical_spawn_queue.processing.jsonl"

--- a/on-modify-nautical.py
+++ b/on-modify-nautical.py
@@ -255,10 +255,16 @@ def _append_next_wait_sched_rows(
 # ------------------------------------------------------------------------------
 # Locate nautical_core (single fixed location: ~/.task)
 # ------------------------------------------------------------------------------
+
+try:
+    # Get the fifth argument and remove the "data:" prefix
+    hook_data_arg = len(sys.argv) > 5 and len(sys.argv[5]) >= 5 and Path(sys.argv[5][5:])
+except Exception:
+    hook_data_arg = None
+
 HOOK_DIR = Path(__file__).resolve().parent
 TW_DIR = HOOK_DIR.parent
-
-TW_DATA_DIR = Path(os.environ.get("TASKDATA") or str(TW_DIR)).expanduser()
+TW_DATA_DIR = hook_data_arg or Path(os.environ.get("TASKDATA") or str(TW_DIR)).expanduser()
 
 # ------------------------------------------------------------------------------
 # Deferred next-link spawn queue (used when nested `task import` times out due to TW lock)


### PR DESCRIPTION
Fix #8 

Set `TW_DATA_DIR` to `data:` argument of [Hooks v2 API](https://taskwarrior.org/docs/hooks2/) if it set.
This fixes a setup with a separated configuration and data directory.

The argument used before the environment variable `TASKDATA`, because if this variable is set, then TW `data.location` is also redefined by this variable.

This code should be shared in the core, but it's not easy to set TW_DATA_DIR with lazy loading of the core module.

This code should be shared in the core, but it's not easy (for me) to set `TW_DATA_DIR` when core module is lazy loaded.